### PR TITLE
Support https

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,8 @@ lazy val root = (project in file("."))
 //    Compile / mainClass := Some("dependencies.cli.Main"),
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
     graalVMNativeImageOptions ++= Seq(
-      "--no-fallback"
+      "--no-fallback",
+      "--enable-url-protocols=https
     )
   )
   .enablePlugins(GraalVMNativeImagePlugin)


### PR DESCRIPTION
I was having this error
```
timestamp=2022-06-27T19:49:44.573307Z level=ERROR thread=#zio-fiber-0 message="" cause="Exception in thread "zio-fiber-6" java.lang.Error: java.lang.Error: download error: Caught java.net.MalformedURLException (Accessing an URL protocol that was not enabled. The URL protocol https is supported but not enabled by default. It must be enabled by adding the --enable-url-protocols=https option to the native-image command.) while downloading https://repo1.maven.org/maven2/com/lihaoyi/acyclic_2.13/maven-metadata.xml
	at dependencies.versions.VersionsLive.getVersions(VersionsLive.scala:40)
	at dependencies.versions.VersionsLive.getVersions(VersionsLive.scala:41)
	at dependencies.versions.VersionsLive.getVersions(VersionsLive.scala:44)
	at dependencies.versions.VersionsLive.getVersions(VersionsLive.scala:16)
	at dependencies.DependencyUpdater.getUpgradeOptions(DependencyUpdater.scala:58)
	at dependencies.DependencyUpdater.allUpdateOptions(DependencyUpdater.scala:32)
	at dependencies.Main.run(Main.scala:13)
	at dependencies.Main.run(Main.scala:26)"
```

this PR fixes it...